### PR TITLE
Add Open Graph Protocol image

### DIFF
--- a/themes/cayman/layouts/partials/head.html
+++ b/themes/cayman/layouts/partials/head.html
@@ -14,6 +14,10 @@
   <link rel="stylesheet" href="{{ $caymanCss.Permalink }}">
   <link rel="apple-touch-icon" sizes="1024x1024" href="/icon-1024.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/icon-32.png">
+  <meta property="og:title" content="{{ .Title }} | {{ $.Site.Title }}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://jointakahe.org/" />
+  <meta property="og:image" content="https://jointakahe.org/icon-1024.png" />
   {{ partial "katex.html" . }}
   <title>{{ .Title }} | {{ $.Site.Title }}</title>
 </head>


### PR DESCRIPTION
I noticed the current webpage has no Open Graph Protocol metadata so when we introduced Takahē with the website link in a post, we cannot see the nice Takahē icon.

## Before
<img width="769" alt="Screenshot 2023-08-06 at 20 56 40" src="https://github.com/jointakahe/jointakahe/assets/1425259/ba6ca378-da9c-4a7a-921c-330590bfd751">

## After

tested at https://shuuji3.github.io/tmp/

<img width="588" alt="Screenshot 2023-08-06 at 21 25 46" src="https://github.com/jointakahe/jointakahe/assets/1425259/a8f40281-5484-494d-b4fb-065d0cffe5ee">

## On Elk

<img src="https://github.com/jointakahe/jointakahe/assets/1425259/b21aed69-b064-413c-8589-75554a3b09bd" width="400">

https://elk.zone/mastodon.social/@shuuji3@takahe.social/110842541911649153
